### PR TITLE
Send repository update message only if updates should be sent

### DIFF
--- a/lib/redmine_messenger/hooks.rb
+++ b/lib/redmine_messenger/hooks.rb
@@ -10,7 +10,7 @@ module RedmineMessenger
       channels = Messenger.channels_for_project issue.project
       url = Messenger.url_for_project issue.project
 
-      return unless channels.present? && url && issue.save
+      return unless channels.present? && url && issue.save && Messenger.setting_for_project(issue.project, :post_updates)
       return if issue.is_private? && !Messenger.setting_for_project(issue.project, :post_private_issues)
 
       msg = "[#{ERB::Util.html_escape(issue.project)}] #{ERB::Util.html_escape(journal.user.to_s)} updated <#{Messenger.object_url issue}|#{ERB::Util.html_escape(issue)}>"


### PR DESCRIPTION
The plugin sent messages about ticket updates to the platforms on version control changesets even if ticket updates were disabled.
This commit fixes this issue.