### PR TITLE
Add a Japanese support

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,50 @@
+# Japanese strings
+ja:
+  permission_manage_messenger: メッセンジャーの管理
+  label_messenger_contact_created: "[%{project_url}] コンタクト %{url} が *%{user}* によって作成されました。"
+  label_messenger_contact_updated: "[%{project_url}] コンタクト %{url} が*%{user}* によって更新されました。"
+  label_messenger_db_entry_created: "[%{project_url}] DB entry %{url} created by *%{user}*"
+  label_messenger_db_entry_updated: "[%{project_url}] DB entry %{url} updated by *%{user}*"
+  label_messenger_default_not_visible: デフォルトの設定はセキュリティ上の理由により表示されません。
+  label_messenger_issue_created: "[%{project_url}] チケット %{url} が *%{user}* によって作成されました。"
+  label_messenger_issue_updated: "[%{project_url}] チケット %{url} が *%{user}* によって更新されました。"
+  label_messenger_password_created: "[%{project_url}] Kennwort %{url} created by *%{user}*"
+  label_messenger_password_updated: "[%{project_url}] Kennwort %{url} updated by *%{user}*"
+  label_messenger_project_text_field_info: デフォルトの設定を使う場合空欄にしてください。
+  label_messenger_settings_default: デフォルト
+  label_messenger_settings_disabled: 無効
+  label_messenger_settings_enabled: 有効
+  label_messenger_wiki_created: "[%{project_url}] Wiki %{url} が by *%{user}* によって作成されました。"
+  label_messenger_wiki_updated: "[%{project_url}] Wiki %{url} が *%{user}* によって更新されました。"
+  label_messenger: メッセンジャー
+  label_settings_auto_mentions: ユーザー名をその人についての投稿(@ユーザー名)に変換する
+  label_settings_display_watchers: ウォッチャーを表示する
+  label_settings_messenger_channel: メッセンジャーのチャンネル
+  label_settings_messenger_icon: メッセンジャーのアイコン
+  label_settings_messenger_url: メッセンジャーのURL
+  label_settings_messenger_username: メッセンジャーのユーザー名
+  label_settings_messenger_verify_ssl: SSL証明書の検証
+  label_settings_new_include_description: チケット作成時に説明を含める
+  label_settings_post_contact_updates: コンタクトの更新
+  label_settings_post_contact: コンタクトの作成
+  label_settings_post_db_updates: DB entry updates?
+  label_settings_post_db: DB entry added?
+  label_settings_post_password_updates: Password updates?
+  label_settings_post_password: Password added?
+  label_settings_post_private_issues: プライベートチケットの更新
+  label_settings_post_private_notes: プライベート注記の更新
+  label_settings_post_updates: チケットの更新
+  label_settings_post_wiki_updates: Wikiの更新
+  label_settings_post_wiki: Wikiの作成
+  label_settings_updated_include_description: チケット更新時に説明を含める
+  messenger_channel_info_html: チャンネルを指定する必要があります。複数のチャンネルを指定する場合は,(カンマ)で区切って下さい。
+  messenger_contacts_intro: メッセンジャーに送信するチケットのイベントにチェックを入れて下さい。
+  messenger_db_intro: Activate the changes for DB that should be sent to the pre-defined Messenger channel.
+  messenger_issue_intro: メッセンジャーに送信するチケットのイベントにチェックを入れて下さい。
+  messenger_passwords_intro: Activate the changes for Passwords that should be sent to the pre-defined Messenger channel.
+  messenger_settings_intro: 管理画面でメッセンジャーのURLを指定した場合、全てのプロジェクトのデフォルトの送信先になります。プロジェクト毎の送信先を設定する場合はプロジェクトの設定画面で設定して下さい。
+  messenger_settings_project_intro: メッセンジャーのURLを指定しない場合、管理者が指定したチャンネルにメッセージが送信されます。(管理者がチャンネルを指定していない場合は、空欄にすると機能は無効になります)
+  messenger_url_info_html: 'メッセンジャー サービスで <a target="_blank" href="https://github.com/AlphaNodes/redmine_messenger#prepare-your-messenger-service">内向きのウェブフック</a>のURLを作成して下さい。プロジェクト毎に設定を変えたい場合は空欄として下さい。'
+  messenger_verify_ssl_info_html: 'メッセンジャー サービスが自己署名証明書や不正な証明書を使っている場合、無効として下さい。'
+  messenger_wiki_intro: メッセンジャーに送信するWikiのイベントにチェックを入れて下さい。
+  label_messenger_setting: メッセンジャーの設定


### PR DESCRIPTION
This commit adds a Japanese support.
Redmine and Mattermost have an official Japanese support. But the plugin not.
So I have written a locale file ya.yml for Japanese speakers.