### PR TITLE
Add option to include Assignee in issue update

### DIFF
--- a/app/views/settings/_messenger_settings.html.erb
+++ b/app/views/settings/_messenger_settings.html.erb
@@ -59,6 +59,10 @@
   <%= check_box_tag 'settings[new_include_description]', 1, @settings[:new_include_description].to_i == 1 %>
 </p>
 <p>
+  <%= content_tag(:label, l(:label_settings_updated_include_assignee)) %>
+  <%= check_box_tag 'settings[updated_include_assignee]', 1, @settings[:updated_include_assignee].to_i == 1 %>
+</p>
+<p>
   <%= content_tag(:label, l(:label_settings_updated_include_description)) %>
   <%= check_box_tag 'settings[updated_include_description]', 1, @settings[:updated_include_description].to_i == 1 %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
   label_settings_post_updates: Issue updates?
   label_settings_post_wiki_updates: Wiki updates?
   label_settings_post_wiki: Post Wiki added?
+  label_settings_updated_include_assignee: Assignee in update issue?
   label_settings_updated_include_description: Description in update issue?
   messenger_channel_info_html: 'Here you have to specify the channel, which should be used. You can define multible channels, seperated by comma'
   messenger_contacts_intro: Activate the changes for Issues that should be sent to the pre-defined Messenger channel.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -37,6 +37,7 @@ ja:
   label_settings_post_updates: チケットの更新
   label_settings_post_wiki_updates: Wikiの更新
   label_settings_post_wiki: Wikiの作成
+  label_settings_updated_include_assignee: チケット更新時に担当者を含める
   label_settings_updated_include_description: チケット更新時に説明を含める
   messenger_channel_info_html: チャンネルを指定する必要があります。複数のチャンネルを指定する場合は,(カンマ)で区切って下さい。
   messenger_contacts_intro: メッセンジャーに送信するチケットのイベントにチェックを入れて下さい。

--- a/init.rb
+++ b/init.rb
@@ -26,6 +26,7 @@ Redmine::Plugin.register :redmine_messenger do
     display_watchers: '0',
     post_updates: '1',
     new_include_description: '1',
+    updated_include_assignee: '0',
     updated_include_description: '1',
     post_private_issues: '1',
     post_private_notes: '1',

--- a/lib/redmine_messenger/patches/issue_patch.rb
+++ b/lib/redmine_messenger/patches/issue_patch.rb
@@ -70,8 +70,16 @@ module RedmineMessenger
           if current_journal.notes.present? && Messenger.setting_for_project(project, :updated_include_description)
             attachment[:text] = ERB::Util.html_escape(current_journal.notes)
           end
+          attachment[:fields] = []
+          if RedmineMessenger.setting?(:updated_include_assignee)
+            attachment[:fields] << {
+              title: I18n.t(:field_assigned_to),
+              value: ERB::Util.html_escape(assigned_to.to_s),
+              short: true
+            }
+          end
           fields = current_journal.details.map { |d| Messenger.detail_to_field d }
-          attachment[:fields] = fields if fields.any?
+          attachment[:fields] += fields if fields.any?
 
           Messenger.speak(l(:label_messenger_issue_updated,
                             project_url: "<#{Messenger.object_url project}|#{ERB::Util.html_escape(project)}>",


### PR DESCRIPTION
Hi,

This PR adds an option to include "Assignee" field in issue update.
Here are the screenshots of setting and notification message.

Please note that I have not update `config/locales/de.yml` as I could not.

![issue-setting](https://user-images.githubusercontent.com/238681/34326816-37519bce-e8f9-11e7-9b0a-4c2cd6280146.png)

![slack-update](https://user-images.githubusercontent.com/238681/34326820-3973c364-e8f9-11e7-8628-c04d3d659f57.png)