### PR TITLE
Fix formatting error of estimated_hours

### DIFF
--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -206,7 +206,7 @@ class Messenger
       when 'tracker'
         value = object_field_value(Tracker, detail.value)
       when 'estimated_hours'
-        value = format_hours(value)
+        value = format_hours(value.is_a?(String) ? (value.to_hours || value) : value)
       when 'project'
         value = object_field_value(Project, detail.value)
       when 'status'


### PR DESCRIPTION
To fix following error on Redmine 4.1.1
* Setting to trigger error: `Setting.timespan_format == 'minutes'`
![image](https://user-images.githubusercontent.com/84070/79300230-b4f32e00-7f18-11ea-91df-fcda91e31932.png)
```ruby
def format_hours(hours)
  return "" if hours.blank?

  if Setting.timespan_format == 'minutes'
    h = hours.floor                        
    m = ((hours - h) * 60).round
    "%d:%02d" % [ h, m ]
  else
    "%.2f" % hours.to_f
  end
end
```
* The error: format_hours requires argument in Float
```
NoMethodError (undefined method `floor' for "1.0":String):

lib/redmine/i18n.rb:90:in `format_hours'
plugins/redmine_messenger/app/models/messenger.rb:209:in `detail_to_field'
```
* Fix: Use redmine's `to_hours` convention on estimated_hours, which should allow value in Float or String type
```
lib/redmine/core_ext/string/conversions.rb
29:        def to_hours

app/models/issue.rb
454:    write_attribute :estimated_hours, (h.is_a?(String) ? (h.to_hours || h) : h)
```