### PR TITLE
add a ability of ignoring the update by the assigned person

### DIFF
--- a/app/controllers/messenger_settings_controller.rb
+++ b/app/controllers/messenger_settings_controller.rb
@@ -32,6 +32,7 @@ class MessengerSettingsController < ApplicationController
                                     :updated_include_description,
                                     :post_private_issues,
                                     :post_private_notes,
+                                    :post_own_issues,
                                     :post_wiki,
                                     :post_wiki_updates,
                                     :post_db,

--- a/app/views/messenger_settings/_show.html.slim
+++ b/app/views/messenger_settings/_show.html.slim
@@ -40,6 +40,7 @@
     = render partial: 'messenger_settings/messenger_select', locals: { f: f, mf: :updated_include_description }
     = render partial: 'messenger_settings/messenger_select', locals: { f: f, mf: :post_private_issues }
     = render partial: 'messenger_settings/messenger_select', locals: { f: f, mf: :post_private_notes }
+    = render partial: 'messenger_settings/messenger_select', locals: { f: f, mf: :post_own_issues }
 
   fieldset#messenger_settings.box.tabular
     legend = l(:label_wiki)

--- a/app/views/settings/_messenger_settings.html.slim
+++ b/app/views/settings/_messenger_settings.html.slim
@@ -51,6 +51,9 @@ fieldset#messenger_settings.box.tabular
   p
     = content_tag(:label, l(:label_settings_post_private_notes))
     = check_box_tag 'settings[post_private_notes]', 1, @settings[:post_private_notes].to_i == 1
+  p
+    = content_tag(:label, l(:label_settings_post_own_issues))
+    = check_box_tag 'settings[post_own_issues]', 1, @settings[:post_own_issues].to_i == 1
 
 fieldset#messenger_settings.box.tabular
   legend = l(:label_wiki)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -40,6 +40,7 @@ de:
   label_settings_post_private_issues: Private Ticket Updates?
   label_settings_post_private_notes: Private Notizen?
   label_settings_post_updates: Ticket Updates?
+  label_settings_post_own_issues: Your Update Of Your Own Tickets?
   label_settings_post_wiki_updates: Wiki Updates?
   label_settings_post_wiki: Neue Wikis?
   label_settings_updated_include_description: Ticket Beschreibungsupdates?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
   label_settings_post_private_issues: Private issue updates?
   label_settings_post_private_notes: Private notes updates?
   label_settings_post_updates: Issue updates?
+  label_settings_post_own_issues: Your update of your own issues?
   label_settings_post_wiki_updates: Wiki updates?
   label_settings_post_wiki: Post Wiki added?
   label_settings_updated_include_description: Description in update issue?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -40,6 +40,7 @@ fr:
   label_settings_post_private_issues: Inclure les mises à jour des tickets privés
   label_settings_post_private_notes: Inclure les mises à jour des notes privées
   label_settings_post_updates: Inclure toutes les mises à jour
+  label_settings_post_own_issues: Mise à jour du ticket ?
   label_settings_post_wiki_updates: Inclure les mises à jour du wiki
   label_settings_post_wiki: Inclure les publications du wiki
   label_settings_updated_include_description: Inclure la description suite à une mise à jour

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,6 +40,7 @@ ja:
   label_settings_post_private_issues: プライベートチケットの更新
   label_settings_post_private_notes: プライベート注記の更新
   label_settings_post_updates: チケットの更新
+  label_settings_post_own_issues: 自分のチケットを自分で更新
   label_settings_post_wiki_updates: Wikiの更新
   label_settings_post_wiki: Wikiの作成
   label_settings_updated_include_description: チケット更新時に説明を含める

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -40,6 +40,7 @@ ko:
   label_settings_post_private_issues: 비공개 일감을 포함
   label_settings_post_private_notes: 비공개 노트를 포함
   label_settings_post_updates: 일감 수정
+  label_settings_post_own_issues: 자신의 티켓 업데이트
   label_settings_post_wiki_updates: 위키 수정
   label_settings_post_wiki: 위키 추가
   label_settings_updated_include_description: 수정된 일감의 설명을 포함

--- a/db/migrate/001_create_messenger_settings.rb
+++ b/db/migrate/001_create_messenger_settings.rb
@@ -14,6 +14,7 @@ class CreateMessengerSettings < ActiveRecord::Migration[4.2]
       t.integer :updated_include_description, default: 0, null: false
       t.integer :post_private_issues, default: 0, null: false
       t.integer :post_private_notes, default: 0, null: false
+      t.integer :post_own_issues, default: 0, null: false
       t.integer :post_wiki, default: 0, null: false
       t.integer :post_wiki_updates, default: 0, null: false
       t.integer :post_db, default: 0, null: false

--- a/init.rb
+++ b/init.rb
@@ -28,6 +28,7 @@ Redmine::Plugin.register :redmine_messenger do
     post_private_db: '0',
     post_private_issues: '0',
     post_private_notes: '0',
+    post_own_issues: '1',
     post_wiki: '0',
     post_wiki_updates: '0',
     post_db: '0',

--- a/lib/redmine_messenger/patches/issue_patch.rb
+++ b/lib/redmine_messenger/patches/issue_patch.rb
@@ -17,6 +17,8 @@ module RedmineMessenger
 
           return unless channels.present? && url
           return if is_private? && !Messenger.setting_for_project(project, :post_private_issues)
+          return if !Messenger.setting_for_project(project, :post_own_issues) && \
+                    assigned_to.present? && assigned_to.to_s.eql?(author.to_s)
 
           set_language_if_valid Setting.default_language
 
@@ -66,6 +68,8 @@ module RedmineMessenger
           return unless channels.present? && url && Messenger.setting_for_project(project, :post_updates)
           return if is_private? && !Messenger.setting_for_project(project, :post_private_issues)
           return if current_journal.private_notes? && !Messenger.setting_for_project(project, :post_private_notes)
+          return if !Messenger.setting_for_project(project, :post_own_issues) && \
+                    assigned_to.present? && assigned_to.to_s.eql?(current_journal.user.to_s)
 
           set_language_if_valid Setting.default_language
 


### PR DESCRIPTION
I added a flag about the update by the assigned person.
If you turn off the flag, messenger does not notify the update which is updated by the assigned person.
I added the ability description in the setting menu in Japanese and just translated it to other language by google. So I'll appreciate that someone update the description.
