### PR TITLE
Added feature to send messages directly to users to be notified

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Features
   * post db entry (if redmine_db is installed) updates
   * post password (if redmine_passwords is installed) updates
   * post contact (if redmine_contacts is installed) updates
+* Post information directly to users to be notified (users names should be the same in Redmine and chat). Tested with Rocket.Chat
 * overwrite messenger settings at project level
 * parent project support (inherit messenger settings from parent project)
 * multiple channel support (define one or more channels to deliver note)

--- a/app/controllers/messenger_settings_controller.rb
+++ b/app/controllers/messenger_settings_controller.rb
@@ -24,6 +24,7 @@ class MessengerSettingsController < ApplicationController
                                     :messenger_channel,
                                     :messenger_username,
                                     :messenger_verify_ssl,
+                                    :messenger_direct_users_messages,
                                     :auto_mentions,
                                     :default_mentions,
                                     :display_watchers,

--- a/app/views/messenger_settings/_show.html.slim
+++ b/app/views/messenger_settings/_show.html.slim
@@ -27,6 +27,7 @@
     = render partial: 'messenger_settings/messenger_text', locals: { f: f, mf: :messenger_channel, size: 30 }
     = render partial: 'messenger_settings/messenger_text', locals: { f: f, mf: :messenger_username, size: 30 }
     = render partial: 'messenger_settings/messenger_select', locals: { f: f, mf: :messenger_verify_ssl }
+    = render partial: 'messenger_settings/messenger_select', locals: { f: f, mf: :messenger_direct_users_messages }
 
   fieldset#messenger_settings.box.tabular
     legend = l(:label_issue_plural)

--- a/app/views/settings/_messenger_settings.html.slim
+++ b/app/views/settings/_messenger_settings.html.slim
@@ -21,6 +21,10 @@ fieldset#messenger_settings.box.tabular
     = tag.label l(:label_settings_messenger_verify_ssl)
     = check_box_tag 'settings[messenger_verify_ssl]', 1, @settings[:messenger_verify_ssl].to_i == 1
     em.info = t(:messenger_verify_ssl_info_html)
+  p
+    = tag.label l(:label_settings_messenger_direct_users_messages)
+    = check_box_tag 'settings[messenger_direct_users_messages]', 1, @settings[:messenger_direct_users_messages].to_i == 1
+    em.info = t(:messenger_direct_users_messages_info_html)
 
 fieldset#messenger_settings.box.tabular
   legend = l(:label_issue_plural)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
   label_settings_messenger_url: Messenger URL
   label_settings_messenger_username: Messenger username
   label_settings_messenger_verify_ssl: Verify SSL
+  label_settings_messenger_direct_users_messages: Send direct messages
   label_settings_new_include_description: New issue description?
   label_settings_post_contact_updates: Contact updates?
   label_settings_post_contact: Contact added?
@@ -52,5 +53,6 @@ en:
   messenger_settings_project_intro: "If you left empty the Messenger URL in the administration area in case to be not globally notified by all project changes you can configure your Messenger URL in the project settings."
   messenger_url_info_html: 'Generate an <a target="_blank" href="https://github.com/AlphaNodes/redmine_messenger#prepare-your-messenger-service">Incoming WebHook</a> URL from the messenger service. Leave it empty, if you only want to activate specific projects with project based settings'
   messenger_verify_ssl_info_html: 'If your Messenger service uses an invalid or self-signed SSL certificate, disable it.'
+  messenger_direct_users_messages_info_html: 'If enabled Messenger will post http requests to each user as channel(direct message in RocketChat) along with post in channel'
   messenger_wiki_intro: Activate the changes for Wikis that should be sent to the pre-defined Messenger channel.
   permission_manage_messenger: Manage messenger

--- a/db/migrate/004_add_direct_messages.rb
+++ b/db/migrate/004_add_direct_messages.rb
@@ -1,0 +1,5 @@
+class AddDirectMessages < ActiveRecord::Migration[4.2]
+  def change
+    add_column :messenger_settings, :messenger_direct_users_messages, :integer, default: 0, null: false
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -18,6 +18,7 @@ Redmine::Plugin.register :redmine_messenger do
     messenger_channel: 'redmine',
     messenger_username: 'robot',
     messenger_verify_ssl: '1',
+    messenger_direct_users_messages: '0',
     auto_mentions: '0',
     default_mentions: '',
     display_watchers: '0',

--- a/lib/redmine_messenger/patches/issue_patch.rb
+++ b/lib/redmine_messenger/patches/issue_patch.rb
@@ -15,6 +15,14 @@ module RedmineMessenger
           channels = Messenger.channels_for_project project
           url = Messenger.url_for_project project
 
+          if Messenger.setting_for_project(project, :messenger_direct_users_messages)
+            notified_users.each do |user|
+              if user.login != author.login
+                channels.append('@' + user.login)
+              end
+            end
+          end   
+    
           return unless channels.present? && url
           return if is_private? && !Messenger.setting_for_project(project, :post_private_issues)
 
@@ -62,6 +70,14 @@ module RedmineMessenger
 
           channels = Messenger.channels_for_project project
           url = Messenger.url_for_project project
+          
+          if Messenger.setting_for_project(project, :messenger_direct_users_messages)
+            notified_users.each do |user|
+              if user.login != current_journal.user.login
+                channels.append('@' + user.login)
+              end
+            end
+          end  
 
           return unless channels.present? && url && Messenger.setting_for_project(project, :post_updates)
           return if is_private? && !Messenger.setting_for_project(project, :post_private_issues)


### PR DESCRIPTION
If users logins are the same in redmine and RocketChat it is possible to post messages not only in channel but directly to users to be notified.