### PR TITLE
Add journal anchor to issue update notification URL

### DIFF
--- a/lib/redmine_messenger/patches/issue_patch.rb
+++ b/lib/redmine_messenger/patches/issue_patch.rb
@@ -107,7 +107,11 @@ module RedmineMessenger
              Messenger.textfield_for_project(project, :default_mentions).present?
             mention_to = Messenger.mentions project, text
           end
-          "<#{Messenger.object_url self}|#{Messenger.markup_format self}>#{mention_to}"
+          if current_journal.nil?
+            "<#{Messenger.object_url self}|#{Messenger.markup_format self}>#{mention_to}"
+          else
+            "<#{Messenger.object_url self}#change-#{current_journal.id}|#{Messenger.markup_format self}>#{mention_to}"
+          end
         end
       end
     end


### PR DESCRIPTION
I'd like to add journal anchor to issue update notification URL, so that clicking URL shows the updated note.
i.e. When updating issue `123`, URL will be `.../issues/123#change-456` instead of `.../issues/123`.

This is a naive fix for it.