### PR TITLE
Move update comment to attachment field

### DIFF
--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -159,16 +159,6 @@ class Messenger
     def attachment_text_from_journal(journal)
       obj = journal.details.detect { |j| j.prop_key == 'description' && j.property == 'attr' }
       text = obj.value if obj.present?
-
-      if journal.notes.present?
-        if text.present?
-          text << "\n\n*#{l :label_comment}*\n"
-          text << journal.notes
-        else
-          text = journal.notes
-        end
-      end
-
       text.present? ? markup_format(text) : nil
     end
 

--- a/lib/redmine_messenger/patches/issue_patch.rb
+++ b/lib/redmine_messenger/patches/issue_patch.rb
@@ -88,6 +88,11 @@ module RedmineMessenger
           end
 
           fields = current_journal.details.map { |d| Messenger.detail_to_field(d, project) }
+          if current_journal.notes.present?
+            fields << { title: I18n.t(:label_comment),
+                        value: Messenger.markup_format(current_journal.notes),
+                        short: false }
+          end
           fields << { title: I18n.t(:field_is_private), short: true } if current_journal.private_notes?
           fields.compact!
           attachment[:fields] = fields if fields.any?


### PR DESCRIPTION
Hi, this changes to move issue update comment to attachment field so that comment is not hidden when issue description is long.

Before the change,
![image](https://user-images.githubusercontent.com/238681/99922709-4828f780-2d75-11eb-9682-75f163cd8f9f.png)

After the change,
![image](https://user-images.githubusercontent.com/238681/99922758-81616780-2d75-11eb-86ce-d5c9d647cc85.png)

This also fixes comment is not notified if `Description in update issue?` is not checked.


