### PR TITLE
Support Group assignee as well as User

### DIFF
--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -236,7 +236,7 @@ class Messenger
       when 'category'
         value = object_field_value IssueCategory, detail.value
       when 'assigned_to', 'author'
-        value = object_field_value User, detail.value
+        value = object_field_value Principal, detail.value
       when 'fixed_version'
         value = object_field_value Version, detail.value
       when 'attachment'


### PR DESCRIPTION
Given `Allow issue assignment to groups` is checked in Redmine Issue tracking setting.

If an issue is assigned to a group, ID is notified instead of Group name. This change fixes the problem.

Before fix,
![image](https://user-images.githubusercontent.com/238681/99924370-6266d380-2d7d-11eb-851a-2f4a0cd4afa7.png)

After fix,
![image](https://user-images.githubusercontent.com/238681/99924455-b5d92180-2d7d-11eb-8c9a-f9ad2f919330.png)

Also, checked User assigned case and Issue creation cases, and they worked.
