### PR TITLE
Do not modify non-frozen string in markup_format()

### DIFF
--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -12,7 +12,7 @@ class Messenger
       #
       # Redmine::WikiFormatting.html_parser.to_text(text)
 
-      text = +text.to_s
+      text = text.to_s.dup
 
       # @see https://api.slack.com/reference/surfaces/formatting#escaping
 


### PR DESCRIPTION
If `text` argument in `markup_format()` is non-frozen string, `+text.to_s`
is identical to `text` and it is modified in the method.

This change fixes the problem by duplicating `text`.

I don't know the exact condition to make the problem happen.
The problem does not happen in my test environment, but I have one environment where it happens.
As a result, the issue Description is actually modified by it.