### PR TITLE
Fix URL formatting in messages

### DIFF
--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -77,11 +77,11 @@ class Messenger
     end
 
     def project_url_markdown(project)
-      "[#{project.name}](#{object_url project})"
+      "<#{object_url project}|#{project.name}>"
     end
 
     def url_markdown(obj, name)
-      "[#{name}](#{object_url obj})"
+      "<#{object_url obj}|#{name}>"
     end
 
     def textfield_for_project(proj, config)


### PR DESCRIPTION
Certain URLs in the Messenger are formatted as Markdown, which [doesn't work with Slack](https://stackoverflow.com/a/36304585). URLs elsewhere are formatted correctly, so this change addresses the inconsistency and fixes the links for Slack.

Fixes #75