### PR TITLE
Add filtering for sending messages by issue tracker and status

### DIFF
--- a/app/controllers/messenger_settings_controller.rb
+++ b/app/controllers/messenger_settings_controller.rb
@@ -44,6 +44,8 @@ class MessengerSettingsController < ApplicationController
                                     :post_contact_updates,
                                     :post_private_contacts,
                                     :post_password,
-                                    :post_password_updates
+                                    :post_password_updates,
+                                    filter_issue_trackers: [],
+                                    filter_issue_statuses: []
   end
 end

--- a/app/models/messenger_setting.rb
+++ b/app/models/messenger_setting.rb
@@ -15,4 +15,24 @@ class MessengerSetting < ActiveRecord::Base
 
     setting
   end
+
+  def filter_issue_statuses=(value)
+    super(value.reject(&:empty?).join(','))
+  end
+
+  def filter_issue_statuses
+    return self[:filter_issue_statuses].split(',').map(&:to_i) if self[:filter_issue_statuses]
+
+    self[:filter_issue_statuses]
+  end
+
+  def filter_issue_trackers=(value)
+    super(value.reject(&:empty?).join(','))
+  end
+
+  def filter_issue_trackers
+    return self[:filter_issue_trackers].split(',').map(&:to_i) if self[:filter_issue_trackers]
+
+    self[:filter_issue_trackers]
+  end
 end

--- a/app/views/messenger_settings/_messenger_multi_select.html.slim
+++ b/app/views/messenger_settings/_messenger_multi_select.html.slim
@@ -1,0 +1,7 @@
+p
+  = f.select mf, method(data_source).call(@messenger_setting.send(mf)), { label: l("label_settings_#{mf}") }, { multiple: true, size: 5 }
+  '
+  em.info style="display: inline;"
+    = l :label_default
+    ' :
+    = l :label_all

--- a/app/views/messenger_settings/_show.html.slim
+++ b/app/views/messenger_settings/_show.html.slim
@@ -31,6 +31,8 @@
     legend = l :label_issue_plural
     .info = t :messenger_issue_intro
     br
+    = render 'messenger_settings/messenger_multi_select', f: f, mf: :filter_issue_trackers, data_source: :issue_trackers
+    = render 'messenger_settings/messenger_multi_select', f: f, mf: :filter_issue_statuses, data_source: :issue_statuses
     = render 'messenger_settings/messenger_select', f: f, mf: :auto_mentions
     = render 'messenger_settings/messenger_text', f: f, mf: :default_mentions, size: 30
     = render 'messenger_settings/messenger_select', f: f, mf: :display_watchers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
   label_messenger_wiki_created: "%{project_url} - Wiki %{url} created by *%{user}*"
   label_messenger_wiki_updated: "%{project_url} - Wiki %{url} updated by *%{user}*"
   label_messenger: Messenger
+  label_settings_filter_issue_statuses: Notify when issue status is
+  label_settings_filter_issue_trackers: Notify when issue tracker is
   label_settings_auto_mentions: Convert names to mentions?
   label_settings_default_mentions: Default people for mentions
   label_settings_display_watchers: Display watchers?
@@ -43,6 +45,7 @@ en:
   label_settings_post_wiki_updates: Wiki updates?
   label_settings_post_wiki: Post Wiki added?
   label_settings_updated_include_description: Description in update issue?
+  label_all: All
   messenger_channel_info_html: 'Here you have to specify the channel, which should be used. You can define multiple channels, seperated by comma'
   messenger_contacts_intro: Activate the changes for Issues that should be sent to the pre-defined Messenger channel.
   messenger_db_intro: Activate the changes for DB that should be sent to the pre-defined Messenger channel.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,8 @@ messenger_channel: 'redmine'
 messenger_username: 'robot'
 messenger_verify_ssl: 1
 messenger_direct_users_messages: 0
+filter_issue_trackers: ''
+filter_issue_statuses: ''
 auto_mentions: 0
 default_mentions: ''
 display_watchers: 0

--- a/db/migrate/005_add_filter_issue_statuses.rb
+++ b/db/migrate/005_add_filter_issue_statuses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFilterIssueStatuses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :messenger_settings, :filter_issue_statuses, :string, default: '', null: false
+  end
+end

--- a/db/migrate/006_add_filter_issue_trackers.rb
+++ b/db/migrate/006_add_filter_issue_trackers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFilterIssueTrackers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :messenger_settings, :filter_issue_trackers, :string, default: '', null: false
+  end
+end

--- a/lib/redmine_messenger/helpers.rb
+++ b/lib/redmine_messenger/helpers.rb
@@ -8,6 +8,20 @@ module RedmineMessenger
                            l(:label_messenger_settings_enabled) => '2' }, active)
     end
 
+    def issue_statuses(active)
+      options_for_select(
+        IssueStatus.sorted.map { |s| [s.name, s.id] },
+        active
+      )
+    end
+
+    def issue_trackers(active)
+      options_for_select(
+        Tracker.sorted.map { |s| [s.name, s.id] },
+        active
+      )
+    end
+
     def project_setting_messenger_default_value(value)
       if Messenger.default_project_setting @project, value
         l :label_messenger_settings_enabled

--- a/lib/redmine_messenger/patches/issue_patch.rb
+++ b/lib/redmine_messenger/patches/issue_patch.rb
@@ -14,6 +14,8 @@ module RedmineMessenger
 
       module InstanceMethods
         def send_messenger_create
+          filter_issue_trackers = Messenger.textfield_for_project project, :filter_issue_trackers
+          filter_issue_statuses = Messenger.textfield_for_project project, :filter_issue_statuses
           channels = Messenger.channels_for_project project
           url = Messenger.url_for_project project
 
@@ -25,6 +27,8 @@ module RedmineMessenger
 
           return unless channels.present? && url
           return if is_private? && !Messenger.setting_for_project(project, :post_private_issues)
+          return if !filter_issue_trackers.empty? && filter_issue_trackers.exclude?(tracker.id)
+          return if !filter_issue_statuses.empty? && filter_issue_statuses.exclude?(status.id)
 
           initial_language = ::I18n.locale
           begin
@@ -73,6 +77,8 @@ module RedmineMessenger
         def send_messenger_update
           return if current_journal.nil?
 
+          filter_issue_trackers = Messenger.textfield_for_project project, :filter_issue_trackers
+          filter_issue_statuses = Messenger.textfield_for_project project, :filter_issue_statuses
           channels = Messenger.channels_for_project project
           url = Messenger.url_for_project project
 
@@ -85,6 +91,8 @@ module RedmineMessenger
           return unless channels.present? && url && Messenger.setting_for_project(project, :post_updates)
           return if is_private? && !Messenger.setting_for_project(project, :post_private_issues)
           return if current_journal.private_notes? && !Messenger.setting_for_project(project, :post_private_notes)
+          return if !filter_issue_trackers.empty? && filter_issue_trackers.exclude?(tracker.id)
+          return if !filter_issue_statuses.empty? && filter_issue_statuses.exclude?(status.id)
 
           initial_language = ::I18n.locale
           begin


### PR DESCRIPTION
Added ability to send message only for specified trackers or statuses.
E.g. I want to see, if there is a reported bug (tracker: bug, status: new) and if someone took it (status: in progress), but i do not need to know, that it done.

Similar to https://github.com/AlphaNodes/redmine_messenger/pull/99, but I changed the text field to multi-select, as you pointed out and added trackers.
Also, this resolves https://github.com/AlphaNodes/redmine_messenger/issues/96