### PR TITLE
Convert assignees and watchers to Slack mentions

### DIFF
--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -267,6 +267,15 @@ class Messenger
       obj.nil? ? id.to_s : obj.to_s
     end
 
+    def convert_to_slack_mention(user)
+      "<@#{user.mail.split("@")[0]}>"
+    end
+
+    def object_field_mention(klass, id)
+      obj = klass.find_by id: id
+      obj.nil? ? id.to_s : convert_to_slack_mention(obj)
+    end
+
     def extract_usernames(text)
       return [] if text.blank?
 

--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -215,7 +215,7 @@ class Messenger
       when 'category'
         value = object_field_value IssueCategory, detail.value
       when 'assigned_to', 'author'
-        value = object_field_value Principal, detail.value
+        value = object_field_mention Principal, detail.value
       when 'fixed_version'
         value = object_field_value Version, detail.value
       when 'attachment'
@@ -268,7 +268,7 @@ class Messenger
     end
 
     def convert_to_slack_mention(user)
-      "<@#{user.mail.split("@")[0]}>"
+      "@#{user.mail.split("@")[0]}"
     end
 
     def object_field_mention(klass, id)

--- a/lib/redmine_messenger/patches/issue_patch.rb
+++ b/lib/redmine_messenger/patches/issue_patch.rb
@@ -145,7 +145,7 @@ module RedmineMessenger
         end
 
         def convert_to_slack_mention(user)
-          "<@#{user.mail.split("@")[0]}>"
+          "@#{user.mail.split("@")[0]}"
         end
       end
     end


### PR DESCRIPTION
We modified this plugin to convert assignees and watchers into mentions in Slack to easily be alerted when you're assigned to something or an issue that you watch changes. The current state of this PR is just for Slack (Slack allows @-ing people with the part before the company e-mail address) so it's not a general solution that works across messengers. But in case you would like to incorporate this and put it behind a config toggle or something I figured I'd leave the code here.